### PR TITLE
Refactor DeleteConfirmationModal to use children for body content

### DIFF
--- a/src/components/DeleteConfirmationModal.test.tsx
+++ b/src/components/DeleteConfirmationModal.test.tsx
@@ -14,7 +14,8 @@ function renderModal(
   const user = userEvent.setup();
   const props: DeleteConfirmationModalProps = {
     opened: true,
-    itemName: "workout",
+    title: "Delete workout",
+    children: "Are you sure?",
     onClose: vi.fn(),
     onDelete: vi.fn(),
     ...propsOverrides,
@@ -28,22 +29,20 @@ function renderModal(
 }
 
 describe("DeleteConfirmationModal", () => {
-  it("renders the modal title with itemName", () => {
-    renderModal({ itemName: "exercise" });
+  it("renders the modal title", () => {
+    renderModal({ title: "Delete exercise" });
     expect(screen.getByText("Delete exercise")).toBeInTheDocument();
   });
 
-  it("renders the confirmation message with itemName", () => {
-    renderModal({ itemName: "exercise" });
+  it("renders children as the body content", () => {
+    renderModal({ children: "This will remove it from every day." });
     expect(
-      screen.getByText(
-        "Are you sure you want to permanently delete this exercise?",
-      ),
+      screen.getByText("This will remove it from every day."),
     ).toBeInTheDocument();
   });
 
   it("does not render modal content when opened is false", () => {
-    renderModal({ opened: false, itemName: "exercise" });
+    renderModal({ opened: false, title: "Delete exercise" });
     expect(screen.queryByText("Delete exercise")).not.toBeInTheDocument();
   });
 

--- a/src/components/DeleteConfirmationModal.tsx
+++ b/src/components/DeleteConfirmationModal.tsx
@@ -1,23 +1,20 @@
 import { Button, Flex, Modal } from "@mantine/core";
+import { ReactNode } from "react";
 
 export interface DeleteConfirmationModalProps {
   opened: boolean;
-  itemName: string;
+  title: string;
+  children: ReactNode;
   onClose: () => void;
   onDelete: () => void;
 }
 
 export function DeleteConfirmationModal(props: DeleteConfirmationModalProps) {
-  const { opened, itemName, onClose, onDelete } = props;
+  const { opened, title, children, onClose, onDelete } = props;
 
   return (
-    <Modal
-      centered
-      title={`Delete ${itemName}`}
-      opened={opened}
-      onClose={onClose}
-    >
-      Are you sure you want to permanently delete this {itemName}?
+    <Modal centered title={title} opened={opened} onClose={onClose}>
+      {children}
       <Flex justify="flex-end" gap="xs" mt="lg">
         <Button variant="default" onClick={onClose}>
           Cancel

--- a/src/components/ExerciseForm.tsx
+++ b/src/components/ExerciseForm.tsx
@@ -260,11 +260,13 @@ export function ExerciseForm(props: ExerciseFormProps) {
           </Flex>
         </form.AppForm>
         <DeleteConfirmationModal
+          title="Delete warm-up set"
           opened={isDeleteModalOpen}
-          itemName="warm-up set"
           onClose={() => setIsDeleteModalOpen(false)}
           onDelete={handleDeleteWarmUpSet}
-        />
+        >
+          Are you sure you want to permanently delete this warm-up set?
+        </DeleteConfirmationModal>
       </form>
 
       <Modal

--- a/src/components/PlanDay.tsx
+++ b/src/components/PlanDay.tsx
@@ -161,11 +161,14 @@ export function PlanDay(props: PlanDayProps) {
         />
       </Modal>
       <DeleteConfirmationModal
-        itemName="exercise"
+        title="Delete exercise"
         opened={isDeleteModalOpen}
         onClose={() => setIsDeleteModalOpen(false)}
         onDelete={handleDeleteExercise}
-      />
+      >
+        Are you sure you want to permanently delete this exercise? It will be
+        removed from every day in your plan.
+      </DeleteConfirmationModal>
     </div>
   );
 

--- a/src/components/PlanWorkoutPage.tsx
+++ b/src/components/PlanWorkoutPage.tsx
@@ -99,11 +99,13 @@ export function PlanWorkoutPage() {
         />
       </Modal>
       <DeleteConfirmationModal
-        itemName="day"
+        title="Delete day"
         opened={isDeleteModalOpen}
         onClose={() => setIsDeleteModalOpen(false)}
         onDelete={() => handleDeleteDay()}
-      />
+      >
+        Are you sure you want to permanently delete this day?
+      </DeleteConfirmationModal>
     </>
   );
 


### PR DESCRIPTION
Replace itemName prop with title and children to allow custom messaging per call site. This enables the exercise delete dialog to warn that the exercise will be removed from every day in the plan.

Closes #62 