### PR TITLE
Remove redundant idToReplace params from upsert helpers

### DIFF
--- a/src/components/PlanDay.tsx
+++ b/src/components/PlanDay.tsx
@@ -214,7 +214,6 @@ export function PlanDay(props: PlanDayProps) {
             exerciseDefinitionId: exerciseDefinition.id,
             definitionTrainingLoadBeforeCompletion: null,
           },
-          exerciseToEdit?.id,
         ),
         ...upsertWorkoutExerciseDefinition(workout, exerciseDefinition),
       },

--- a/src/components/PlanWorkoutPage.tsx
+++ b/src/components/PlanWorkoutPage.tsx
@@ -116,7 +116,7 @@ export function PlanWorkoutPage() {
     setIsDayModalOpen(false);
     await updateWorkout({
       workoutId: workout.id,
-      updates: upsertWorkoutDay(workout, day, dayToEdit?.id),
+      updates: upsertWorkoutDay(workout, day),
     });
   }
 

--- a/src/utils/workoutMutationHelpers.test.ts
+++ b/src/utils/workoutMutationHelpers.test.ts
@@ -26,7 +26,7 @@ import {
 } from "./workoutMutationHelpers";
 
 describe("upsertWorkoutDay", () => {
-  it("adds a day when no dayToReplaceId is provided", () => {
+  it("adds a day when the id does not exist", () => {
     const day1 = makeDay({ id: "day1", name: "Day 1" });
     const workout = makeWorkout({ days: [day1] });
 
@@ -38,14 +38,13 @@ describe("upsertWorkoutDay", () => {
     expect(updates.days.map((day) => day.id)).toEqual(["day1", "day2"]);
   });
 
-  it("replaces an existing day when dayToReplaceId is provided", () => {
+  it("replaces an existing day when the id already exists", () => {
     const day1 = makeDay({ id: "day1", name: "Day 1" });
     const workout = makeWorkout({ days: [day1] });
 
     const updates = upsertWorkoutDay(
       workout,
       makeDay({ id: "day1", name: "Updated" }),
-      "day1",
     );
 
     expect(updates.days[0].name).toBe("Updated");
@@ -76,7 +75,7 @@ describe("reorderWorkoutDay", () => {
 });
 
 describe("upsertWorkoutDayExercise", () => {
-  it("adds an exercise when exerciseToReplaceId is not provided", () => {
+  it("adds an exercise when the id does not exist", () => {
     const day = makeDay({
       id: "day1",
       exercises: [makeDayExercise({ id: "ex1", exerciseDefinitionId: "def1" })],
@@ -95,7 +94,7 @@ describe("upsertWorkoutDayExercise", () => {
     ]);
   });
 
-  it("replaces an existing exercise when exerciseToReplaceId is provided", () => {
+  it("replaces an existing exercise when the id already exists", () => {
     const day = makeDay({
       id: "day1",
       exercises: [makeDayExercise({ id: "ex1", exerciseDefinitionId: "def1" })],
@@ -106,7 +105,6 @@ describe("upsertWorkoutDayExercise", () => {
       workout,
       "day1",
       makeDayExercise({ id: "ex1", exerciseDefinitionId: "def2" }),
-      "ex1",
     );
 
     expect(updates.days[0].exercises[0].exerciseDefinitionId).toBe("def2");

--- a/src/utils/workoutMutationHelpers.ts
+++ b/src/utils/workoutMutationHelpers.ts
@@ -12,15 +12,17 @@ import { selectExerciseDefinition } from "./workoutSelectors";
 export function upsertWorkoutDay(
   workout: Workout,
   day: Day,
-  dayToReplaceId?: string,
 ): Pick<Workout, "days"> {
-  if (!dayToReplaceId) {
+  const isUpdate = workout.days.some(
+    (existingDay) => existingDay.id === day.id,
+  );
+  if (!isUpdate) {
     return { days: [...workout.days, day] };
   }
 
   return {
     days: workout.days.map((existingDay) => {
-      return existingDay.id === dayToReplaceId ? day : existingDay;
+      return existingDay.id === day.id ? day : existingDay;
     }),
   };
 }
@@ -48,7 +50,6 @@ export function upsertWorkoutDayExercise(
   workout: Workout,
   dayId: string,
   exercise: DayExercise,
-  exerciseToReplaceId?: string,
 ): Pick<Workout, "days"> {
   return {
     days: workout.days.map((day) => {
@@ -56,14 +57,17 @@ export function upsertWorkoutDayExercise(
         return day;
       }
 
-      if (!exerciseToReplaceId) {
+      const isUpdate = day.exercises.some(
+        (existingExercise) => existingExercise.id === exercise.id,
+      );
+      if (!isUpdate) {
         return { ...day, exercises: [...day.exercises, exercise] };
       }
 
       return {
         ...day,
         exercises: day.exercises.map((existingExercise) => {
-          return existingExercise.id === exerciseToReplaceId
+          return existingExercise.id === exercise.id
             ? exercise
             : existingExercise;
         }),


### PR DESCRIPTION
The upsert functions now derive insert-vs-update from whether the object's id already exists in the collection, eliminating the redundant separate id parameter.

Closes #51 