### PR TITLE
Remove trivial property-accessor selectors and inline their usages

### DIFF
--- a/src/components/ExerciseCompleteForm.tsx
+++ b/src/components/ExerciseCompleteForm.tsx
@@ -4,7 +4,6 @@ import z from "zod";
 import { useAppForm } from "../hooks/useAppForm";
 import { ExerciseDefinition } from "../types/ExerciseDefinition";
 import { TrainingLoad } from "../types/TrainingLoad";
-import { selectExerciseTrainingLoad } from "../utils/workoutSelectors";
 
 export interface ExerciseCompleteFormProps {
   exerciseDefinition: ExerciseDefinition;
@@ -33,7 +32,7 @@ const formSchema = z.object({
 
 export function ExerciseCompleteForm(props: ExerciseCompleteFormProps) {
   const { exerciseDefinition, onSave } = props;
-  const currentTrainingLoad = selectExerciseTrainingLoad(exerciseDefinition);
+  const currentTrainingLoad = exerciseDefinition.trainingLoad;
 
   const form = useAppForm({
     defaultValues: {

--- a/src/components/PlanDay.tsx
+++ b/src/components/PlanDay.tsx
@@ -24,11 +24,7 @@ import {
   upsertWorkoutDayExercise,
   upsertWorkoutExerciseDefinition,
 } from "../utils/workoutMutationHelpers";
-import {
-  selectDayExercises,
-  selectExerciseDefinition,
-  selectWorkoutDays,
-} from "../utils/workoutSelectors";
+import { selectExerciseDefinition } from "../utils/workoutSelectors";
 import { AddExerciseModalContent } from "./AddExerciseModalContent";
 import { DeleteConfirmationModal } from "./DeleteConfirmationModal";
 import { ExerciseForm } from "./ExerciseForm";
@@ -63,9 +59,7 @@ export function PlanDay(props: PlanDayProps) {
     null,
   );
   const { mutate: updateWorkout } = useUpdateWorkoutMutation();
-  const workoutDays = selectWorkoutDays(workout);
-  const dayExercises = selectDayExercises(day);
-  const dayIndex = workoutDays.findIndex((d) => d.id === day.id);
+  const dayIndex = workout.days.findIndex((d) => d.id === day.id);
 
   const exerciseDefinitionToEdit = exerciseToEdit
     ? selectExerciseDefinition(workout, exerciseToEdit)
@@ -109,13 +103,13 @@ export function PlanDay(props: PlanDayProps) {
       </Title>
       <Divider mt={4} mb="md" />
       <Flex direction="column" gap="md">
-        {dayExercises.length === 0 && (
+        {day.exercises.length === 0 && (
           <div>
             Your plan has no exercises for this day. Click the button below to
             add an exercise.
           </div>
         )}
-        {dayExercises.map((exercise, index) => {
+        {day.exercises.map((exercise, index) => {
           return (
             <PlanExerciseCard
               key={exercise.id}
@@ -123,8 +117,8 @@ export function PlanDay(props: PlanDayProps) {
               exercise={exercise}
               moveUpDisabled={index === 0 && dayIndex === 0}
               moveDownDisabled={
-                index === dayExercises.length - 1 &&
-                dayIndex === workoutDays.length - 1
+                index === day.exercises.length - 1 &&
+                dayIndex === workout.days.length - 1
               }
               onEdit={handleEditExercise}
               onDuplicate={handleDuplicateExercise}

--- a/src/components/PlanWorkoutPage.tsx
+++ b/src/components/PlanWorkoutPage.tsx
@@ -19,7 +19,6 @@ import {
   reorderWorkoutDay,
   upsertWorkoutDay,
 } from "../utils/workoutMutationHelpers";
-import { selectWorkoutDays } from "../utils/workoutSelectors";
 import { CreateWorkoutEmptyState } from "./CreateWorkoutEmptyState";
 import { DayForm } from "./DayForm";
 import { DeleteConfirmationModal } from "./DeleteConfirmationModal";
@@ -56,7 +55,7 @@ export function PlanWorkoutPage() {
     );
   }
 
-  const workoutDays = selectWorkoutDays(workout);
+  const workoutDays = workout.days;
 
   return (
     <>

--- a/src/utils/workoutSelectors.test.ts
+++ b/src/utils/workoutSelectors.test.ts
@@ -11,7 +11,6 @@ import { ExerciseType } from "../types/ExerciseType";
 import { WarmUpType } from "../types/WarmUpType";
 import {
   selectCompletedDayExercises,
-  selectDayExercises,
   selectDayHasCompletedExercises,
   selectDayIsComplete,
   selectExerciseIsComplete,
@@ -19,30 +18,11 @@ import {
   selectIncompleteDayExercises,
   selectIncompleteWorkoutDays,
   selectWarmUpSetWeight,
-  selectWorkoutDays,
   selectWorkoutDaysWithCompletedExercises,
   selectWorkoutHasNoDays,
   selectWorkoutHasNoExercises,
   selectWorkoutIsComplete,
 } from "./workoutSelectors";
-
-describe("selectWorkoutDays", () => {
-  it("returns workout days", () => {
-    const day = makeDay({ id: "day1" });
-    const workout = makeWorkout({ days: [day] });
-
-    expect(selectWorkoutDays(workout)).toEqual([day]);
-  });
-});
-
-describe("selectDayExercises", () => {
-  it("returns day exercises", () => {
-    const exercise = makeDayExercise({ id: "ex1" });
-    const day = makeDay({ exercises: [exercise] });
-
-    expect(selectDayExercises(day)).toEqual([exercise]);
-  });
-});
 
 describe("selectExerciseIsComplete", () => {
   it("returns true when all working sets are logged", () => {

--- a/src/utils/workoutSelectors.ts
+++ b/src/utils/workoutSelectors.ts
@@ -2,31 +2,16 @@ import { Day } from "../types/Day";
 import { DayExercise } from "../types/DayExercise";
 import { ExerciseDefinition } from "../types/ExerciseDefinition";
 import { ExerciseType } from "../types/ExerciseType";
-import { TrainingLoad } from "../types/TrainingLoad";
 import { WarmUpSet } from "../types/WarmUpSet";
 import { WarmUpType } from "../types/WarmUpType";
 import { Workout } from "../types/Workout";
 import { weightOfBar } from "./weightUtils";
-
-export function selectWorkoutDays(workout: Workout): Day[] {
-  return workout.days;
-}
-
-export function selectDayExercises(day: Day): DayExercise[] {
-  return day.exercises;
-}
 
 export function selectExerciseDefinition(
   workout: Workout,
   exercise: DayExercise,
 ): ExerciseDefinition | undefined {
   return workout.exerciseDefinitionsById[exercise.exerciseDefinitionId];
-}
-
-export function selectExerciseTrainingLoad(
-  exerciseDefinition: ExerciseDefinition,
-): TrainingLoad {
-  return exerciseDefinition.trainingLoad;
 }
 
 export function selectExerciseIsComplete(
@@ -48,30 +33,30 @@ export function selectDayHasCompletedExercises(
   workout: Workout,
   day: Day,
 ): boolean {
-  return selectDayExercises(day).some((exercise) => {
+  return day.exercises.some((exercise) => {
     return selectExerciseIsComplete(workout, exercise);
   });
 }
 
 export function selectDayIsComplete(workout: Workout, day: Day): boolean {
-  return selectDayExercises(day).every((exercise) => {
+  return day.exercises.every((exercise) => {
     return selectExerciseIsComplete(workout, exercise);
   });
 }
 
 export function selectWorkoutIsComplete(workout: Workout): boolean {
-  return selectWorkoutDays(workout).every((day) => {
+  return workout.days.every((day) => {
     return selectDayIsComplete(workout, day);
   });
 }
 
 export function selectWorkoutHasNoDays(workout: Workout): boolean {
-  return selectWorkoutDays(workout).length === 0;
+  return workout.days.length === 0;
 }
 
 export function selectWorkoutHasNoExercises(workout: Workout): boolean {
-  return selectWorkoutDays(workout).every((day) => {
-    return selectDayExercises(day).length === 0;
+  return workout.days.every((day) => {
+    return day.exercises.length === 0;
   });
 }
 
@@ -79,7 +64,7 @@ export function selectIncompleteDayExercises(
   workout: Workout,
   day: Day,
 ): DayExercise[] {
-  return selectDayExercises(day).filter((exercise) => {
+  return day.exercises.filter((exercise) => {
     return !selectExerciseIsComplete(workout, exercise);
   });
 }
@@ -88,13 +73,13 @@ export function selectCompletedDayExercises(
   workout: Workout,
   day: Day,
 ): DayExercise[] {
-  return selectDayExercises(day).filter((exercise) => {
+  return day.exercises.filter((exercise) => {
     return selectExerciseIsComplete(workout, exercise);
   });
 }
 
 export function selectIncompleteWorkoutDays(workout: Workout): Day[] {
-  return selectWorkoutDays(workout).filter((day) => {
+  return workout.days.filter((day) => {
     return selectIncompleteDayExercises(workout, day).length > 0;
   });
 }
@@ -102,7 +87,7 @@ export function selectIncompleteWorkoutDays(workout: Workout): Day[] {
 export function selectWorkoutDaysWithCompletedExercises(
   workout: Workout,
 ): Day[] {
-  return selectWorkoutDays(workout).filter((day) => {
+  return workout.days.filter((day) => {
     return selectDayHasCompletedExercises(workout, day);
   });
 }


### PR DESCRIPTION
selectWorkoutDays, selectDayExercises, and selectExerciseTrainingLoad just returned a single property with no logic. Inlining them makes the remaining selectors a clearer abstraction boundary: they exist because they contain real computation.