### PR TITLE
Add training load previews to ExerciseCompleteForm

### DIFF
--- a/src/components/CompletedExercise.tsx
+++ b/src/components/CompletedExercise.tsx
@@ -3,8 +3,8 @@ import { Button, Card, Text, Title } from "@mantine/core";
 import { DayExercise } from "../types/DayExercise";
 import { ExerciseDefinition } from "../types/ExerciseDefinition";
 import {
-  getLoggedSetBreakdown,
-  getTrainingLoadString,
+  formatLoggedSetBreakdown,
+  formatTrainingLoad,
 } from "../utils/workoutFormattingUtils";
 
 export interface CompletedExerciseProps {
@@ -24,12 +24,12 @@ export function CompletedExercise(props: CompletedExerciseProps) {
         </Title>
         <Text size="sm" c="dimmed">
           This session:{" "}
-          {getLoggedSetBreakdown(
+          {formatLoggedSetBreakdown(
             exercise.workingSets,
             exerciseDefinition.trainingLoad.weight,
           )}
           <br />
-          Next session: {getTrainingLoadString(exerciseDefinition.trainingLoad)}
+          Next session: {formatTrainingLoad(exerciseDefinition.trainingLoad)}
         </Text>
         <Button
           fullWidth

--- a/src/components/ExerciseCompleteForm.test.tsx
+++ b/src/components/ExerciseCompleteForm.test.tsx
@@ -87,6 +87,44 @@ describe("ExerciseCompleteForm", () => {
     });
   });
 
+  describe("preview descriptions", () => {
+    it("shows correct previews for default training load", () => {
+      renderExerciseCompleteForm({
+        exerciseDefinition: makeExerciseDefinition({
+          minimumWeightIncrement: 5,
+          trainingLoad: { weight: 135, sets: 3, reps: 5 },
+        }),
+      });
+      expect(
+        screen.getByText("Next session: 3 sets of 5 at 135 lbs"),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText("Next session: 3 sets of 6 at 135 lbs"),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText("Next session: 3 sets of 5 at 140 lbs"),
+      ).toBeInTheDocument();
+    });
+
+    it("computes previews for different training loads and increments", () => {
+      renderExerciseCompleteForm({
+        exerciseDefinition: makeExerciseDefinition({
+          minimumWeightIncrement: 2.5,
+          trainingLoad: { weight: 50, sets: 4, reps: 8 },
+        }),
+      });
+      expect(
+        screen.getByText("Next session: 4 sets of 8 at 50 lbs"),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText("Next session: 4 sets of 9 at 50 lbs"),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText("Next session: 4 sets of 8 at 52.5 lbs"),
+      ).toBeInTheDocument();
+    });
+  });
+
   describe("onSave", () => {
     it("saves an empty plan when Do nothing is selected", async () => {
       const { user, onSave } = renderExerciseCompleteForm();

--- a/src/components/ExerciseCompleteForm.tsx
+++ b/src/components/ExerciseCompleteForm.tsx
@@ -4,6 +4,7 @@ import z from "zod";
 import { useAppForm } from "../hooks/useAppForm";
 import { ExerciseDefinition } from "../types/ExerciseDefinition";
 import { TrainingLoad } from "../types/TrainingLoad";
+import { formatTrainingLoadVerbose } from "../utils/workoutFormattingUtils";
 
 export interface ExerciseCompleteFormProps {
   exerciseDefinition: ExerciseDefinition;
@@ -33,6 +34,19 @@ const formSchema = z.object({
 export function ExerciseCompleteForm(props: ExerciseCompleteFormProps) {
   const { exerciseDefinition, onSave } = props;
   const currentTrainingLoad = exerciseDefinition.trainingLoad;
+  const { weight, reps, sets } = currentTrainingLoad;
+
+  const doNothingPreview = formatTrainingLoadVerbose(currentTrainingLoad);
+  const addRepPreview = formatTrainingLoadVerbose({
+    weight,
+    reps: reps + 1,
+    sets,
+  });
+  const addWeightPreview = formatTrainingLoadVerbose({
+    weight: weight + exerciseDefinition.minimumWeightIncrement,
+    reps,
+    sets,
+  });
 
   const form = useAppForm({
     defaultValues: {
@@ -89,17 +103,17 @@ export function ExerciseCompleteForm(props: ExerciseCompleteFormProps) {
                 <Radio
                   mt="md"
                   label="Do nothing"
-                  description="Keep things the same for next session"
+                  description={`Next session: ${doNothingPreview}`}
                   value={NextSessionAction.DoNothing}
                 />
                 <Radio
                   label="Add a rep"
-                  description="Add a single rep for next session"
+                  description={`Next session: ${addRepPreview}`}
                   value={NextSessionAction.AddRep}
                 />
                 <Radio
                   label="Add weight"
-                  description="Increases weight by the minimum amount for next session"
+                  description={`Next session: ${addWeightPreview}`}
                   value={NextSessionAction.AddWeight}
                 />
                 <Radio

--- a/src/components/PastWorkoutCard.tsx
+++ b/src/components/PastWorkoutCard.tsx
@@ -1,7 +1,7 @@
 import { Box, Card, Flex, Text } from "@mantine/core";
 
 import { Workout } from "../types/Workout";
-import { getLoggedSetBreakdown } from "../utils/workoutFormattingUtils";
+import { formatLoggedSetBreakdown } from "../utils/workoutFormattingUtils";
 import { selectExerciseDefinition } from "../utils/workoutSelectors";
 
 export interface PastWorkoutCardProps {
@@ -39,7 +39,7 @@ export function PastWorkoutCard(props: PastWorkoutCardProps) {
                   return (
                     <span key={exercise.id}>
                       {exerciseDefinition.name}:{" "}
-                      {getLoggedSetBreakdown(
+                      {formatLoggedSetBreakdown(
                         exercise.workingSets,
                         exerciseDefinition.trainingLoad.weight,
                       )}

--- a/src/components/PlanExerciseCard.tsx
+++ b/src/components/PlanExerciseCard.tsx
@@ -3,7 +3,7 @@ import { IconDots } from "@tabler/icons-react";
 
 import { DayExercise } from "../types/DayExercise";
 import { Workout } from "../types/Workout";
-import { getTrainingLoadString } from "../utils/workoutFormattingUtils";
+import { formatTrainingLoad } from "../utils/workoutFormattingUtils";
 import { selectExerciseDefinition } from "../utils/workoutSelectors";
 
 export interface PlanExerciseCardProps {
@@ -79,7 +79,7 @@ export function PlanExerciseCard(props: PlanExerciseCardProps) {
         </Menu>
       </Flex>
       <Text c="dimmed" size="sm">
-        {getTrainingLoadString(exerciseDefinition.trainingLoad)} with{" "}
+        {formatTrainingLoad(exerciseDefinition.trainingLoad)} with{" "}
         {exerciseDefinition.warmUpSets.length} warm-up sets.
       </Text>
     </Card>

--- a/src/utils/workoutFormattingUtils.test.ts
+++ b/src/utils/workoutFormattingUtils.test.ts
@@ -1,28 +1,43 @@
 import { describe, expect, it } from "vitest";
 
 import {
-  getLoggedSetBreakdown,
-  getTrainingLoadString,
+  formatLoggedSetBreakdown,
+  formatTrainingLoad,
+  formatTrainingLoadVerbose,
 } from "./workoutFormattingUtils";
 
-describe("getVolumeLoad", () => {
+describe("formatTrainingLoad", () => {
   it("formats sets x reps x weight as a string", () => {
-    expect(getTrainingLoadString({ sets: 3, reps: 5, weight: 135 })).toBe(
+    expect(formatTrainingLoad({ sets: 3, reps: 5, weight: 135 })).toBe(
       "3x5x135",
     );
   });
 
   it("works with fractional weight values", () => {
-    expect(getTrainingLoadString({ sets: 4, reps: 8, weight: 112.5 })).toBe(
+    expect(formatTrainingLoad({ sets: 4, reps: 8, weight: 112.5 })).toBe(
       "4x8x112.5",
     );
   });
 });
 
-describe("getLoggedSetBreakdown", () => {
+describe("formatTrainingLoadVerbose", () => {
+  it("formats weight, reps, and sets as a sentence", () => {
+    expect(formatTrainingLoadVerbose({ weight: 150, reps: 5, sets: 3 })).toBe(
+      "3 sets of 5 at 150 lbs",
+    );
+  });
+
+  it("works with fractional weight values", () => {
+    expect(formatTrainingLoadVerbose({ weight: 112.5, reps: 8, sets: 4 })).toBe(
+      "4 sets of 8 at 112.5 lbs",
+    );
+  });
+});
+
+describe("formatLoggedSetBreakdown", () => {
   it("formats reps and logged weights per set with comma-space separation", () => {
     expect(
-      getLoggedSetBreakdown(
+      formatLoggedSetBreakdown(
         {
           0: { isLogged: true, reps: 5, weight: 135 },
           1: { isLogged: true, reps: 4, weight: 130 },
@@ -34,7 +49,7 @@ describe("getLoggedSetBreakdown", () => {
 
   it("uses fallback value when weight is missing from logged set", () => {
     expect(
-      getLoggedSetBreakdown(
+      formatLoggedSetBreakdown(
         {
           0: { isLogged: true, reps: 5, weight: null },
         },

--- a/src/utils/workoutFormattingUtils.ts
+++ b/src/utils/workoutFormattingUtils.ts
@@ -1,11 +1,23 @@
 import { TrainingLoad } from "../types/TrainingLoad";
 import { WorkingSet } from "../types/WorkingSet";
 
-export function getTrainingLoadString(trainingLoad: TrainingLoad): string {
-  return `${trainingLoad.sets}x${trainingLoad.reps}x${trainingLoad.weight}`;
+export function formatTrainingLoad({
+  sets,
+  reps,
+  weight,
+}: TrainingLoad): string {
+  return `${sets}x${reps}x${weight}`;
 }
 
-export function getLoggedSetBreakdown(
+export function formatTrainingLoadVerbose({
+  sets,
+  reps,
+  weight,
+}: TrainingLoad): string {
+  return `${sets} sets of ${reps} at ${weight} lbs`;
+}
+
+export function formatLoggedSetBreakdown(
   workingSets: Record<number, WorkingSet>,
   fallbackWeight: number,
 ): string {


### PR DESCRIPTION
Show concrete next-session previews (e.g. "3 sets of 5 at 140 lbs") on the Do nothing, Add a rep, and Add weight radio options so users know exactly what each choice produces. Rename formatting utils to use a consistent "format" prefix: formatTrainingLoad, formatTrainingLoadVerbose, formatLoggedSetBreakdown.